### PR TITLE
Potential fix for code scanning alert no. 131: Potentially unsafe quoting

### DIFF
--- a/core/services/s4/envelope.go
+++ b/core/services/s4/envelope.go
@@ -59,19 +59,28 @@ func (e Envelope) GetSignerAddress(signature []byte) (address common.Address, er
 }
 
 func (e Envelope) ToJson() ([]byte, error) {
-	address, err := json.Marshal(e.Address)
-	if err != nil {
-		return nil, err
-	}
 	nonNilPayload := e.Payload
 	if nonNilPayload == nil {
 		// prevent unwanted "null" values in JSON representation
 		nonNilPayload = []byte{}
 	}
-	payload, err := json.Marshal(nonNilPayload)
-	if err != nil {
-		return nil, err
+
+	// define a local struct to control JSON field order and tags
+	type envelopeJSON struct {
+		Address    []byte `json:"address"`
+		SlotID     uint   `json:"slotid"`
+		Payload    []byte `json:"payload"`
+		Version    uint64 `json:"version"`
+		Expiration int64  `json:"expiration"`
 	}
-	js := fmt.Sprintf(`{"address":%s,"slotid":%d,"payload":%s,"version":%d,"expiration":%d}`, address, e.SlotID, payload, e.Version, e.Expiration)
-	return []byte(js), nil
+
+	data := envelopeJSON{
+		Address:    e.Address,
+		SlotID:     e.SlotID,
+		Payload:    nonNilPayload,
+		Version:    e.Version,
+		Expiration: e.Expiration,
+	}
+
+	return json.Marshal(data)
 }


### PR DESCRIPTION
Potential fix for [https://github.com/roseteromeo56/chainlink/security/code-scanning/131](https://github.com/roseteromeo56/chainlink/security/code-scanning/131)

General approach: Avoid manually constructing JSON strings with `fmt.Sprintf` using potentially tainted values. Instead, construct a Go value that represents exactly the JSON structure you need and pass it to `json.Marshal`, which correctly escapes quotes and other special characters.

Best fix here: Replace `ToJson`’s manual `fmt.Sprintf` with a small internal struct type that has the desired field ordering and JSON tags. Populate this struct from the `Envelope`, making sure to preserve the existing behavior: base64-encoded `address` and `payload` fields, integer fields as before, and ensuring that `payload` is not serialized as `null` (it should be `""` when the slice is nil). Then call `json.Marshal` on that struct and return the resulting bytes. We keep the JSON key names and order the same by defining the fields in the desired order within the struct.

Concretely, in `core/services/s4/envelope.go`:
- Add a private helper struct type (e.g., `envelopeJSON`) inside `ToJson` (or just before it) with fields `Address []byte`, `SlotID uint`, `Payload []byte`, `Version uint64`, and `Expiration int64`, having the same JSON tags as `Envelope`. Field order in the struct matches the required key order.
- In `ToJson`, keep the existing handling of `nonNilPayload` to avoid `null`, then create an instance of `envelopeJSON` with `Address: e.Address`, `SlotID: e.SlotID`, `Payload: nonNilPayload`, etc.
- Call `json.Marshal` on this struct and return the result.
- Remove the intermediate `json.Marshal` calls for `address` and `payload` and the `fmt.Sprintf` call.

No new imports are needed; `encoding/json` is already imported and `fmt` is still used elsewhere in the file (for error messages), so we keep it.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
