### PR TITLE
Potential fix for code scanning alert no. 130: Potentially unsafe quoting

### DIFF
--- a/core/services/ocr2/plugins/ccip/testhelpers/integration/jobspec.go
+++ b/core/services/ocr2/plugins/ccip/testhelpers/integration/jobspec.go
@@ -20,6 +20,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ccip/internal/pricegetter"
 	"github.com/smartcontractkit/chainlink/v2/core/services/relay"
 	"github.com/smartcontractkit/chainlink/v2/core/store/models"
+	"strings"
 )
 
 // OCR2TaskJobSpec represents an OCR2 job that is given to other nodes, meant to communicate with the bootstrap node,
@@ -239,9 +240,11 @@ func (params CCIPJobSpecParams) CommitJobSpec() (*OCR2TaskJobSpec, error) {
 """`, params.TokenPricesUSDPipeline)
 	}
 	if params.PriceGetterConfig != "" {
+		escapedPriceGetterConfig := strings.ReplaceAll(params.PriceGetterConfig, `\`, `\\`)
+		escapedPriceGetterConfig = strings.ReplaceAll(escapedPriceGetterConfig, `"`, `\"`)
 		pluginConfig["priceGetterConfig"] = fmt.Sprintf(`"""
 %s
-"""`, params.PriceGetterConfig)
+"""`, escapedPriceGetterConfig)
 	}
 
 	ocrSpec := job.OCR2OracleSpec{


### PR DESCRIPTION
Potential fix for [https://github.com/roseteromeo56/chainlink/security/code-scanning/130](https://github.com/roseteromeo56/chainlink/security/code-scanning/130)

In general, the safest fix is to avoid manually constructing quoted string literals around user‑supplied data. Instead, pass such data as structured values (e.g., as JSON objects/strings handled by the consumer) or use an API that takes care of correct quoting/escaping. If manual construction is unavoidable, the embedded string must be escaped appropriately (including quotes and backslashes) before interpolation.

Here, `params.PriceGetterConfig` is already JSON and is being wrapped in a `"""%s"""` literal. The minimal, non‑behavior‑changing fix is to ensure that any `"` and `\` characters in `PriceGetterConfig` are escaped before inserting it into that quoted block. We can do this by adding local escaping in `CommitJobSpec` using the standard library’s `strings.ReplaceAll` (already imported packages do not include `strings`, so we must add that import). Specifically, before the `fmt.Sprintf` call, copy `params.PriceGetterConfig` into a local variable, escape backslashes first, then escape double quotes, and finally interpolate that escaped string into the triple‑quoted template. This retains the surrounding quoting structure while preventing embedded quotes from prematurely terminating the literal.

Concretely, in `core/services/ocr2/plugins/ccip/testhelpers/integration/jobspec.go`:

- Add an import for `strings`.
- In `CommitJobSpec`, change the construction of `pluginConfig["priceGetterConfig"]` to:
  - Create `escapedPriceGetterConfig := strings.ReplaceAll(params.PriceGetterConfig, `\`, `\\`)`.
  - Then `escapedPriceGetterConfig = strings.ReplaceAll(escapedPriceGetterConfig, `"`, `\"`)`.
  - Use `escapedPriceGetterConfig` in the `fmt.Sprintf` call rather than `params.PriceGetterConfig`.

No changes are needed in `integration-tests/ccip-tests/actions/ccip_helpers.go`, since the vulnerability is at the point of quoting in `CommitJobSpec`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
